### PR TITLE
feat(elixir): add hex publish docs action and workflow

### DIFF
--- a/.github/workflows/elixir-hex-publish-docs.yml
+++ b/.github/workflows/elixir-hex-publish-docs.yml
@@ -1,0 +1,38 @@
+on:
+  workflow_call:
+    inputs:
+      elixir-version:
+        description: The Elixir version. It fallback to .tool-versions if not specified
+        type: string
+        required: false
+      otp-version:
+        description: The Erlang version. It fallback to .tool-versions if not specified
+        type: string
+        required: false
+      version-type:
+        description: The versioning type check, either strict or loose
+        type: string
+        required: false
+        default: strict
+      package-name:
+        description: The package name. For umbrella apps, resolves to apps/<package-name>. Omit for single-package repos.
+        type: string
+        required: false
+    secrets:
+      HEX_API_KEY:
+        description: The hex.pm API key
+        required: true
+
+jobs:
+  publish-docs:
+    name: Publish Docs to Hex.pm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+        with:
+          elixir-version: ${{ inputs.elixir-version }}
+          otp-version: ${{ inputs.otp-version }}
+          version-type: ${{ inputs.version-type }}
+          hex-api-key: ${{ secrets.HEX_API_KEY }}
+          package-name: ${{ inputs.package-name }}

--- a/elixir/publish-docs/action.yml
+++ b/elixir/publish-docs/action.yml
@@ -1,0 +1,43 @@
+name: Elixir Publish Docs
+description: Publish an Elixir package documentation to Hex.pm
+author: Straw Hat Team
+
+inputs:
+  elixir-version:
+    description: The Elixir version. It fallback to .tool-versions if not specified
+    required: false
+  otp-version:
+    description: The Erlang version. It fallback to .tool-versions if not specified
+    required: false
+  version-type:
+    description: The versioning type check, either strict or loose
+    required: false
+    default: strict
+  hex-api-key:
+    description: The hex.pm API key
+    required: true
+  package-name:
+    description: The package name. For umbrella apps, resolves to apps/<package-name>. Omit for single-package repos.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Elixir
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      with:
+        elixir-version: ${{ inputs.elixir-version }}
+        otp-version: ${{ inputs.otp-version }}
+        version-type: ${{ inputs.version-type }}
+    - name: Run Hex Publish Docs
+      shell: bash
+      run: |
+        if [ -n "$PACKAGE_NAME" ]; then
+          cd "apps/$PACKAGE_NAME"
+          export MIX_IN_UMBRELLA_DEPS=false
+          mix deps.get
+        fi
+        mix hex.publish docs --yes
+      env:
+        HEX_API_KEY: ${{ inputs.hex-api-key }}
+        PACKAGE_NAME: ${{ inputs.package-name }}


### PR DESCRIPTION
- Publishing docs independently from releases is a common need, especially for triggering on every merge to master without cutting a release
- Supports both single-package repos (omit \`package-name\`) and umbrella apps (pass \`package-name\`, resolves to \`apps/<package-name>\`)