### PR TITLE
chore: bump all actions to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/elixir/dialyzer"
+      - "/elixir/setup"
+      - "/nodejs/setup"
+      - "/semantic-pull-request"
+      - "/stale"
     schedule:
       interval: "monthly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 3

--- a/.github/workflows/elixir-hex-publish-docs.yml
+++ b/.github/workflows/elixir-hex-publish-docs.yml
@@ -28,7 +28,7 @@ jobs:
     name: Publish Docs to Hex.pm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
         with:
           elixir-version: ${{ inputs.elixir-version }}

--- a/.github/workflows/elixir-hex-publish.yml
+++ b/.github/workflows/elixir-hex-publish.yml
@@ -24,7 +24,7 @@ jobs:
     name: Publish to Hex.pm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/elixir/publish@v1.7.7
         with:
           elixir-version: ${{ inputs.elixir-version }}

--- a/.github/workflows/elixir-quality-assurance.yml
+++ b/.github/workflows/elixir-quality-assurance.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Elixir
         uses: straw-hat-team/github-actions-workflows/elixir/setup@master
         with:
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Elixir
         uses: straw-hat-team/github-actions-workflows/elixir/setup@master
         with:
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/elixir/compilation-warnings@master
         with:
           elixir-version: ${{ inputs.elixir-version }}
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/elixir/test@master
         with:
           elixir-version: ${{ inputs.elixir-version }}

--- a/.github/workflows/elixir-quality-assurance.yml
+++ b/.github/workflows/elixir-quality-assurance.yml
@@ -114,7 +114,7 @@ jobs:
     if: ${{ inputs.formatter-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/elixir/format@master
         with:
           elixir-version: ${{ inputs.elixir-version }}
@@ -126,7 +126,7 @@ jobs:
     if: ${{ inputs.credo-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/elixir/credo@master
         with:
           elixir-version: ${{ inputs.elixir-version }}
@@ -138,7 +138,7 @@ jobs:
     if: ${{ inputs.dialyzer-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/elixir/dialyzer@master
         with:
           elixir-version: ${{ inputs.elixir-version }}

--- a/.github/workflows/nodejs-quality-assurance.yml
+++ b/.github/workflows/nodejs-quality-assurance.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ inputs.jest-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/nodejs/setup@v1.7.7
       - shell: sh
         run: yarn install --immutable
@@ -37,7 +37,7 @@ jobs:
     if: ${{ inputs.prettier-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: straw-hat-team/github-actions-workflows/nodejs/setup@v1.7.7
       - shell: sh
         run: yarn install --immutable

--- a/elixir/dialyzer/action.yml
+++ b/elixir/dialyzer/action.yml
@@ -26,7 +26,7 @@ runs:
         version-type: ${{ inputs.version-type }}
 
     - name: Restore PLT cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: plt_cache
       with:
         key: |
@@ -43,7 +43,7 @@ runs:
       run: mix dialyzer --plt
 
     - name: Save PLT cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: steps.plt_cache.outputs.cache-hit != 'true' && steps.create_plts.outcome == 'success'
       id: plt_cache_save
       with:

--- a/elixir/setup/action.yml
+++ b/elixir/setup/action.yml
@@ -35,7 +35,7 @@ runs:
         version-file: .tool-versions
 
     - name: Restore dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/nodejs/setup/action.yml
+++ b/nodejs/setup/action.yml
@@ -18,7 +18,7 @@ runs:
         plugin-name: nodejs
 
     - name: Using Node.js@${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
       env:

--- a/semantic-pull-request/action.yml
+++ b/semantic-pull-request/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Check Pull Request Title
       id: lint_pr_title
-      uses: amannn/action-semantic-pull-request@v5.4.0
+      uses: amannn/action-semantic-pull-request@v6.1.1
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:
@@ -60,7 +60,7 @@ runs:
           ${{ steps.lint_pr_title.outputs.error_message }}
           ```
     - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-      uses: marocchino/sticky-pull-request-comment@v2.9.0
+      uses: marocchino/sticky-pull-request-comment@v3.0.4
       with:
         header: pr-title-lint-error
         delete: true

--- a/semantic-pull-request/action.yml
+++ b/semantic-pull-request/action.yml
@@ -38,7 +38,7 @@ runs:
           doesn't start with an uppercase character.
         wip: true
         validateSingleCommit: true
-    - uses: marocchino/sticky-pull-request-comment@v2.9.0
+    - uses: marocchino/sticky-pull-request-comment@v3.0.4
       if: always() && (steps.lint_pr_title.outputs.error_message != null)
       with:
         header: pr-title-lint-error

--- a/stale/action.yml
+++ b/stale/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: Check stale issues and pull requests
-      uses: actions/stale@v8
+      uses: actions/stale@v10
       with:
         days-before-issue-stale: 30
         days-before-issue-close: 15


### PR DESCRIPTION
- Outdated action versions accumulate security vulnerabilities and miss bug fixes — staying current reduces exposure and ensures compatibility with the latest GitHub Actions runner environments
- `actions/checkout` `v2` → `v6`, `actions/setup-node` `v2` → `v6`, `actions/cache` / `cache/restore` / `cache/save` `v4` → `v5`, `actions/stale` `v8` → `v10`, `amannn/action-semantic-pull-request` `v5.4.0` → `v6.1.1`, `marocchino/sticky-pull-request-comment` `v2.9.0` → `v3.0.4`