### PR TITLE
fix: pin all actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/elixir-hex-publish-docs.yml
+++ b/.github/workflows/elixir-hex-publish-docs.yml
@@ -28,8 +28,8 @@ jobs:
     name: Publish Docs to Hex.pm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}

--- a/.github/workflows/elixir-hex-publish.yml
+++ b/.github/workflows/elixir-hex-publish.yml
@@ -24,8 +24,8 @@ jobs:
     name: Publish to Hex.pm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish@v1.7.7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish@d9f6ba300b84655b70cc33c885e8848f9dde8efa # v1.7.7
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}

--- a/.github/workflows/elixir-quality-assurance.yml
+++ b/.github/workflows/elixir-quality-assurance.yml
@@ -57,9 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Elixir
-        uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+        uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -73,9 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Elixir
-        uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+        uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -89,8 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/compilation-warnings@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/elixir/compilation-warnings@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -102,8 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/test@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/elixir/test@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -114,8 +114,8 @@ jobs:
     if: ${{ inputs.formatter-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/format@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/elixir/format@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -126,8 +126,8 @@ jobs:
     if: ${{ inputs.credo-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/credo@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/elixir/credo@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -138,8 +138,8 @@ jobs:
     if: ${{ inputs.dialyzer-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/dialyzer@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/elixir/dialyzer@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}

--- a/.github/workflows/nodejs-quality-assurance.yml
+++ b/.github/workflows/nodejs-quality-assurance.yml
@@ -22,13 +22,13 @@ jobs:
     if: ${{ inputs.jest-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/nodejs/setup@v1.7.7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/nodejs/setup@d9f6ba300b84655b70cc33c885e8848f9dde8efa # v1.7.7
       - shell: sh
         run: yarn install --immutable
         env:
           SHT_NPM_TOKEN: ${{ secrets.SHT_NPM_TOKEN }}
-      - uses: straw-hat-team/github-actions-workflows/nodejs/jest@v1.7.7
+      - uses: straw-hat-team/github-actions-workflows/nodejs/jest@d9f6ba300b84655b70cc33c885e8848f9dde8efa # v1.7.7
         with:
           sht-npm-token: ${{ secrets.SHT_NPM_TOKEN }}
 
@@ -37,12 +37,12 @@ jobs:
     if: ${{ inputs.prettier-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: straw-hat-team/github-actions-workflows/nodejs/setup@v1.7.7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: straw-hat-team/github-actions-workflows/nodejs/setup@d9f6ba300b84655b70cc33c885e8848f9dde8efa # v1.7.7
       - shell: sh
         run: yarn install --immutable
         env:
           SHT_NPM_TOKEN: ${{ secrets.SHT_NPM_TOKEN }}
-      - uses: straw-hat-team/github-actions-workflows/nodejs/prettier@v1.7.7
+      - uses: straw-hat-team/github-actions-workflows/nodejs/prettier@d9f6ba300b84655b70cc33c885e8848f9dde8efa # v1.7.7
         with:
           sht-npm-token: ${{ secrets.SHT_NPM_TOKEN }}

--- a/elixir/compilation-warnings/action.yml
+++ b/elixir/compilation-warnings/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/credo/action.yml
+++ b/elixir/credo/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/dialyzer/action.yml
+++ b/elixir/dialyzer/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       id: beam
       with:
         elixir-version: ${{ inputs.elixir-version }}
@@ -26,7 +26,7 @@ runs:
         version-type: ${{ inputs.version-type }}
 
     - name: Restore PLT cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       id: plt_cache
       with:
         key: |
@@ -43,7 +43,7 @@ runs:
       run: mix dialyzer --plt
 
     - name: Save PLT cache
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       if: steps.plt_cache.outputs.cache-hit != 'true' && steps.create_plts.outcome == 'success'
       id: plt_cache_save
       with:

--- a/elixir/format/action.yml
+++ b/elixir/format/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/publish-docs/action.yml
+++ b/elixir/publish-docs/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/publish/action.yml
+++ b/elixir/publish/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/setup/action.yml
+++ b/elixir/setup/action.yml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@8251c48667b97e88a0a24ec512f5b72a039fcea7 # v1
       id: setup-beam
       with:
         elixir-version: ${{ inputs.elixir-version }}
@@ -35,7 +35,7 @@ runs:
         version-file: .tool-versions
 
     - name: Restore dependencies cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/elixir/test/action.yml
+++ b/elixir/test/action.yml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/umbrella-publish/action.yml
+++ b/elixir/umbrella-publish/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/nodejs/setup/action.yml
+++ b/nodejs/setup/action.yml
@@ -13,12 +13,12 @@ runs:
     - id: tool-versions-nodejs
       name: Reading NodeJS version from .tool-versions
       if: ${{ ! inputs.nodejs-version }}
-      uses: straw-hat-team/github-actions-workflows/asdf/get-version@master
+      uses: straw-hat-team/github-actions-workflows/asdf/get-version@9d9de721069136b981894947c85a0c27ab14a392 # master
       with:
         plugin-name: nodejs
 
     - name: Using Node.js@${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ env.NODE_VERSION }}
       env:

--- a/semantic-pull-request/action.yml
+++ b/semantic-pull-request/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Check Pull Request Title
       id: lint_pr_title
-      uses: amannn/action-semantic-pull-request@v6.1.1
+      uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:
@@ -38,7 +38,7 @@ runs:
           doesn't start with an uppercase character.
         wip: true
         validateSingleCommit: true
-    - uses: marocchino/sticky-pull-request-comment@v3.0.4
+    - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       if: always() && (steps.lint_pr_title.outputs.error_message != null)
       with:
         header: pr-title-lint-error
@@ -60,7 +60,7 @@ runs:
           ${{ steps.lint_pr_title.outputs.error_message }}
           ```
     - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-      uses: marocchino/sticky-pull-request-comment@v3.0.4
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
         header: pr-title-lint-error
         delete: true

--- a/stale/action.yml
+++ b/stale/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: Check stale issues and pull requests
-      uses: actions/stale@v10
+      uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
       with:
         days-before-issue-stale: 30
         days-before-issue-close: 15


### PR DESCRIPTION
- Consumer repos enforce a policy requiring all actions to be pinned to full-length commit SHAs, which was blocking CI runs in beam-monorepo and potentially other consumers