### PR TITLE
fix: resolve self-reference SHA chain for pinned actions

### DIFF
--- a/.github/workflows/elixir-hex-publish-docs.yml
+++ b/.github/workflows/elixir-hex-publish-docs.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}

--- a/.github/workflows/elixir-hex-publish-docs.yml
+++ b/.github/workflows/elixir-hex-publish-docs.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}

--- a/.github/workflows/elixir-quality-assurance.yml
+++ b/.github/workflows/elixir-quality-assurance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Elixir
-        uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+        uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Elixir
-        uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+        uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/compilation-warnings@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/compilation-warnings@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -103,7 +103,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/test@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/test@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/format@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/format@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/credo@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/credo@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/dialyzer@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/dialyzer@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}

--- a/.github/workflows/elixir-quality-assurance.yml
+++ b/.github/workflows/elixir-quality-assurance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Elixir
-        uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+        uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Elixir
-        uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+        uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/compilation-warnings@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/compilation-warnings@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -103,7 +103,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/test@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/test@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/format@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/format@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/credo@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/credo@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: straw-hat-team/github-actions-workflows/elixir/dialyzer@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/dialyzer@55b445acf7641ffd48132742e4fe278718040d13 # master
         with:
           elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}

--- a/elixir/compilation-warnings/action.yml
+++ b/elixir/compilation-warnings/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/compilation-warnings/action.yml
+++ b/elixir/compilation-warnings/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/credo/action.yml
+++ b/elixir/credo/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/credo/action.yml
+++ b/elixir/credo/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/dialyzer/action.yml
+++ b/elixir/dialyzer/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       id: beam
       with:
         elixir-version: ${{ inputs.elixir-version }}

--- a/elixir/dialyzer/action.yml
+++ b/elixir/dialyzer/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       id: beam
       with:
         elixir-version: ${{ inputs.elixir-version }}

--- a/elixir/format/action.yml
+++ b/elixir/format/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/format/action.yml
+++ b/elixir/format/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/publish-docs/action.yml
+++ b/elixir/publish-docs/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/publish-docs/action.yml
+++ b/elixir/publish-docs/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/publish/action.yml
+++ b/elixir/publish/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/publish/action.yml
+++ b/elixir/publish/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/test/action.yml
+++ b/elixir/test/action.yml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/test/action.yml
+++ b/elixir/test/action.yml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/umbrella-publish/action.yml
+++ b/elixir/umbrella-publish/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/umbrella-publish/action.yml
+++ b/elixir/umbrella-publish/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup Elixir
-      uses: straw-hat-team/github-actions-workflows/elixir/setup@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/nodejs/setup/action.yml
+++ b/nodejs/setup/action.yml
@@ -13,7 +13,7 @@ runs:
     - id: tool-versions-nodejs
       name: Reading NodeJS version from .tool-versions
       if: ${{ ! inputs.nodejs-version }}
-      uses: straw-hat-team/github-actions-workflows/asdf/get-version@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      uses: straw-hat-team/github-actions-workflows/asdf/get-version@55b445acf7641ffd48132742e4fe278718040d13 # master
       with:
         plugin-name: nodejs
 

--- a/nodejs/setup/action.yml
+++ b/nodejs/setup/action.yml
@@ -13,7 +13,7 @@ runs:
     - id: tool-versions-nodejs
       name: Reading NodeJS version from .tool-versions
       if: ${{ ! inputs.nodejs-version }}
-      uses: straw-hat-team/github-actions-workflows/asdf/get-version@9d9de721069136b981894947c85a0c27ab14a392 # master
+      uses: straw-hat-team/github-actions-workflows/asdf/get-version@380a7d55273bbfff3291d0febae9caece989dce6 # master
       with:
         plugin-name: nodejs
 


### PR DESCRIPTION
- The previous pinning commit used the pre-pinning SHA for self-references, causing a chain resolution failure where GitHub would encounter unpinned refs at the old SHA
- Uses a two-commit approach: commit D points self-refs to 380a7d5 (where external actions are pinned), commit E points self-refs to D, so the full chain always resolves to pinned versions