### PR TITLE
feat(semantic-pull-request): enforce conventional commits on every commit

### DIFF
--- a/semantic-pull-request/action.yml
+++ b/semantic-pull-request/action.yml
@@ -13,6 +13,10 @@ inputs:
   scopes:
     description: Configure which scopes are allowed.
     required: false
+  allowed-commit-types:
+    description: Comma-separated list of allowed Conventional Commit types for commit-level validation.
+    required: false
+    default: 'feat,fix,refactor,chore,revert'
 
 runs:
   using: composite
@@ -38,6 +42,10 @@ runs:
           doesn't start with an uppercase character.
         wip: true
         validateSingleCommit: true
+    - name: Check Pull Request Commits
+      uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0
+      with:
+        allowed-commit-types: ${{ inputs.allowed-commit-types }}
     - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       if: always() && (steps.lint_pr_title.outputs.error_message != null)
       with:

--- a/semantic-pull-request/action.yml
+++ b/semantic-pull-request/action.yml
@@ -13,10 +13,6 @@ inputs:
   scopes:
     description: Configure which scopes are allowed.
     required: false
-  allowed-commit-types:
-    description: Comma-separated list of allowed Conventional Commit types for commit-level validation.
-    required: false
-    default: 'feat,fix,refactor,chore,revert'
 
 runs:
   using: composite
@@ -45,7 +41,7 @@ runs:
     - name: Check Pull Request Commits
       uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0
       with:
-        allowed-commit-types: ${{ inputs.allowed-commit-types }}
+        allowed-commit-types: 'feat,fix,refactor,chore,revert'
     - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       if: always() && (steps.lint_pr_title.outputs.error_message != null)
       with:


### PR DESCRIPTION
- Title-only validation lets non-conventional commits land when merge-commits are used, so the squash assumption silently breaks history-driven tooling (changelogs, release-please-style automation) the moment merge strategy changes.
- Centralizing the allow-list in this action keeps every consumer repo aligned on the same set of accepted types without each one re-declaring it.