### PR TITLE
feat(mise): add get-version action

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A set of GitHub Actions Workflow Templates.
 
 - [asdf/get-version](./asdf/get-version/README.md): return the version for a given asdf plugin.
 
+#### mise
+
+- [mise/get-version](./mise/get-version/README.md): return the version for a given mise tool.
+
 #### Elixir-Lang
 
 - [elixir/compilation-warnings](./elixir/compilation-warnings/README.md): compiles the code treating warnings as errors.

--- a/mise/get-version/README.md
+++ b/mise/get-version/README.md
@@ -1,0 +1,29 @@
+# Mise Get Version
+
+Returns the version of the tool from mise.toml file managed by mise.
+
+- [How-to Guides](#how-to-guides)
+
+## How-to Guides
+
+### Get Started
+
+1. Make sure `actions/checkout` action is used before this action.
+2. Add this action to your job in your workflow, here is an example:
+
+    ```yml
+    #...
+    jobs:
+      something:
+        name: Setup NodeJS
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v2 # checkout the repository first
+          - uses: straw-hat-team/github-actions-workflows/mise/get-version@master
+            id: nodejs-version
+            with:
+              plugin-name: nodejs
+          - shell: sh
+            run: |
+              echo ${{ steps.nodejs-version.outputs.plugin-version }}
+    ```

--- a/mise/get-version/action.yml
+++ b/mise/get-version/action.yml
@@ -1,0 +1,41 @@
+name: Mise Get Version
+description: Returns the version of the tool from mise.toml file managed by mise
+author: Straw Hat Team
+
+inputs:
+  plugin-name:
+    description: The name of the tool you want to get the version of
+    required: true
+
+outputs:
+  plugin-version:
+    description: "The version of the tool"
+    value: ${{ steps.get-version.outputs.plugin-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get the version of the tool from mise.toml file
+      id: get-version
+      shell: bash
+      env:
+        PLUGIN_NAME: ${{ inputs.plugin-name }}
+      run: |
+        if [ ! -f mise.toml ]; then
+          echo "mise.toml file not found"
+          exit 1
+        fi
+        PLUGIN_VERSION=$(python3 -c "
+        import os, tomllib
+        with open('mise.toml', 'rb') as f:
+            data = tomllib.load(f)
+        value = data.get('tools', {}).get(os.environ['PLUGIN_NAME'])
+        if isinstance(value, dict):
+            value = value.get('version', '')
+        print(value or '')
+        ")
+        if [ -z "$PLUGIN_VERSION" ]; then
+          echo "'$PLUGIN_NAME' tool not found in mise.toml file"
+          exit 1
+        fi
+        echo "plugin-version=$PLUGIN_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Repos are migrating from asdf's `.tool-versions` to mise's `mise.toml`, so downstream workflows need a version lookup that reads the new format without breaking existing `asdf/get-version` consumers.