### PR TITLE
feat(elixir-quality-assurance): add mix-in-umbrella-deps input

### DIFF
--- a/.github/workflows/elixir-quality-assurance.yml
+++ b/.github/workflows/elixir-quality-assurance.yml
@@ -49,6 +49,14 @@ on:
         type: boolean
         required: false
         default: true
+      mix-in-umbrella-deps:
+        description: Sets MIX_IN_UMBRELLA_DEPS=true so umbrella apps resolve sibling apps as in_umbrella dependencies
+        type: boolean
+        required: false
+        default: false
+
+env:
+  MIX_IN_UMBRELLA_DEPS: ${{ inputs.mix-in-umbrella-deps }}
 
 jobs:
   hex-audit:


### PR DESCRIPTION
- Reusable workflows cannot receive `env` from callers, so umbrella repos had no way to opt mix.exs dep resolution into umbrella mode, forcing mix.exs files to default to `in_umbrella` deps. That default leaks into Hex consumers, whose compiled `.app` files then require optional applications at boot (see `trogon_object_id` 0.1.1 crashing with `could not find application file: trogon_proto.app`).
- An explicit opt-in input lets published packages default to Hex requirements, making the broken-consumer state unrepresentable.