### PR TITLE
fix(elixir): resolve umbrella deps at the repo root during publish setup

### DIFF
--- a/elixir/publish-docs/action.yml
+++ b/elixir/publish-docs/action.yml
@@ -25,6 +25,8 @@ runs:
   steps:
     - name: Setup Elixir
       uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
+      env:
+        MIX_IN_UMBRELLA_DEPS: "true"
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}

--- a/elixir/umbrella-publish/action.yml
+++ b/elixir/umbrella-publish/action.yml
@@ -29,6 +29,8 @@ runs:
   steps:
     - name: Setup Elixir
       uses: straw-hat-team/github-actions-workflows/elixir/setup@55b445acf7641ffd48132742e4fe278718040d13 # master
+      env:
+        MIX_IN_UMBRELLA_DEPS: "true"
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}


### PR DESCRIPTION
- The setup step runs `mix deps.get` at the umbrella root, but umbrella mix.exs files now default to Hex requirements unless `MIX_IN_UMBRELLA_DEPS=true` (the safe default for published packages), so root resolution diverged between umbrella path apps and their Hex requirements and publishes failed before reaching `mix hex.publish`. The publish steps themselves still export `MIX_IN_UMBRELLA_DEPS=false` inside the app directory, which is the correct mode for building the package.